### PR TITLE
Resolve "redefinition of typedef" errors with v5.19.4 and above

### DIFF
--- a/Tty.xs
+++ b/Tty.xs
@@ -58,7 +58,9 @@ typedef FILE * InOutStream;
 #endif /* HAVE_UTIL_H */
 
 #ifdef HAVE_UTIL_H
-# include <util.h>
+# if ((PATCHLEVEL < 19) && (SUBVERSION < 4))
+#  include <util.h>
+# endif
 #endif /* HAVE_UTIL_H */
 
 #ifdef HAVE_PTY_H


### PR DESCRIPTION
On at least OpenBSD and NetBSD with gcc builds fail:

http://www.cpantesters.org/cpan/report/85a7faae-e6b2-11e3-84c4-fc77f9652e90
